### PR TITLE
docs: simplify first-run README onboarding

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -196,7 +196,7 @@ flowchart TB
     F --> G["🫵😿❓ NAZE YATTA?<br/>(なぜやった？ / 何が起きた？)"]
 ```
 
-現在の`v0.1-alpha`が実装しているのは、主に**Mandatory Ruleの決論的Preflight lane**と**Structured Debrief Template**です。Runtime Observation AdapterやWorker自身によるSituational KY生成は、現時点では自動のend-to-end enforcementとしては未実装です。
+現在の`v0.1-alpha`が実装しているのは、主に**Mandatory Ruleの決定論的Preflight lane**と**Structured Debrief Template**です。Runtime Observation AdapterやWorker自身によるSituational KY生成は、現時点では自動のend-to-end enforcementとしては未実装です。
 
 ## KY / 危険予知とは
 
@@ -347,6 +347,7 @@ KY PASS != Authority Granted
 **Helpful != Authorized.**
 
 ## Limitations
+
 NazeYattaは、AI Workerが必ず指示通り動くことを保証しません。PreflightだけではComplianceを強制できません。
 
 高ImpactなActionでは、Worker自身がbypassできないExternal Runtime Gateと組み合わせてください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,23 +2,27 @@
 
 [English](README.md) | [日本語](README.ja.md)
 
-**NazeYatta** は、AI WorkerやSoftware Agentが実際に行動する**前**に、小さなYAMLのTask記述をSafety / Policy Ruleと照合するツールです。
+**NazeYattaは、AIや自動ツールに仕事をさせる前の「チェック係」です。**
 
-`PASS`、`REVIEW`、`EVIDENCE_REQUIRED`、`BLOCK` などの決定論的なPreflight結果と、「何を確認したのか」を示すReceiptを返します。
+たとえば「この写真を公開して」という作業でも、公開してよいことが確認できていなければ `BLOCK` します。確認できた条件については `PASS` / `REVIEW` / `BLOCK` などの結果と、何を確認したかの記録を返します。
+
+NazeYatta自身が仕事を実行するわけではありません。**実行前に、いったん確認するための道具**です。
+
+```text
+あなた / Planner
+      ↓
+「この作業をしたい」
+      ↓
+   NazeYatta
+      ↓
+ PASS / REVIEW / BLOCK
+      ↓
+実際に進めるかは別の権限者が決める
+```
 
 これはalpha段階のresearch toolです。Certification・導入実績・Authority Granting Systemを主張するものではありません。
 
-## いつ使うの？
-
-Workerが記憶・自信・未確認の推測だけで進めてはいけない作業の前に使います。例えば：
-
-- ファイルを削除・変更する前
-- `git push` やその他のexternal writeの前
-- コンテンツを公開する前
-- Permission / Capability / Target / Evidenceの確認が必要な操作の前
-- `UNKNOWN`を「たぶん大丈夫」に勝手に変えてはいけない作業
-
-## まず30秒くらいで動かす
+## まず1回動かす
 
 Python 3.11+ が必要です。
 
@@ -32,7 +36,9 @@ python -m pip install -e .
 nazeyatta check examples/publish-photo.yaml
 ```
 
-次のような結果が出ます。
+このExampleは「外部へ公開したい」という作業です。しかし、公開してよいことがまだ確認できていません。
+
+そのため、次のように `BLOCK` します。
 
 ```text
 NAZEYATTA
@@ -48,17 +54,31 @@ NY-PUB-001  External publication requires verified provenance and permission
 EXECUTION AUTHORITY: NOT GRANTED BY NAZEYATTA
 ```
 
-平たく言うと、このExampleは「外部へ公開したい」というTaskなのに、公開許可がまだ`UNKNOWN`です。そこでNazeYattaは「許可されているはず」と推測せず、Preflightで止めます。
+平たく言えば：
+
+> **「公開していいか分からないので、勝手に進めません。」**
+
+です。
 
 表示はふざけています。**Evidenceはふざけていません。**
 
-## 結果はどう読めばいいの？
+## どんな時に使うの？
 
-- `PASS` — supplied task / policy / evidence が今回のPreflightを通過した
-- `CAUTION` / `REVIEW` / `EVIDENCE_REQUIRED` — 勝手に続行せず、周囲のWorkflowに従ってReviewやEvidenceを得る
-- `BLOCK` — supplied stateではPolicy上そのActionを止める
+AI Workerや自動ツールに、たとえば次のような作業をさせる前です。
 
-CLIのexit statusは保守的です。`PASS`だけが`0`で、`CAUTION / REVIEW / EVIDENCE_REQUIRED / BLOCK`はnon-zeroです。
+- ファイルを削除・変更する
+- `git push` など外部へ書き込む
+- コンテンツを公開する
+- Permission / Capability / Target / Evidenceの確認が必要な操作をする
+- `UNKNOWN`を「たぶん大丈夫」に勝手に変えてほしくない
+
+## 結果はどう読むの？
+
+- `PASS` — 今回渡されたTask / Policy / Evidenceについて、このPreflightを通過した
+- `REVIEW` / `EVIDENCE_REQUIRED` / `CAUTION` — 確認やEvidenceが足りないので、そのまま進めない
+- `BLOCK` — 今回渡された状態では、そのActionを止める
+
+CLIでは `PASS` だけがexit status `0`です。それ以外はnon-zeroです。
 
 一番大事なのはこれです。
 
@@ -66,11 +86,13 @@ CLIのexit statusは保守的です。`PASS`だけが`0`で、`CAUTION / REVIEW 
 KY PASS != Authority Granted
 ```
 
-NazeYattaの`PASS`は**実行権限そのものを付与しません**。実際に実行してよいかは、Caller / Human / Planner / Harness / その他のAuthorized Control Pointが別途判断します。
+**`PASS`は「実行してよい」という権限そのものではありません。** 実際に実行するかは、Human / Planner / Harnessなど、別のAuthorized Control Pointが決めます。
 
-## 自分の最初のTaskを作る
+## NazeYattaには何を渡すの？
 
-Task fileは、「何をするのか」と「何をEvidenceとして評価するのか」を書いた小さなYAML Manifestです。単純なRepository readなら、まずはこの程度から始められます。
+作業内容を小さなYAMLファイルで渡します。
+
+最初は「Repositoryを読むだけ」なら、この程度です。
 
 ```yaml
 task_id: MY-FIRST-READ
@@ -86,45 +108,31 @@ evidence:
   worker_capability_qualified: VERIFIED
 ```
 
-`my-first-task.yaml`として保存し、次を実行します。
+`my-first-task.yaml`として保存して：
 
 ```bash
 nazeyatta check my-first-task.yaml
 ```
 
-### そのfieldは誰が書いていいの？
+と実行します。
 
-v0.1-alphaではOwnership Boundaryを意図的に保守的に扱います。
+### 誰がその情報を書いていいの？
+
+v0.1-alphaでは、ここを保守的に扱います。
 
 - task / action / data の事実は、上流のHuman / Planner / Task Specification / trusted Adapterから供給する
 - evidenceは、そのWorkflowで適切なHuman / trusted Adapter / Evidence Sourceから供給する
 - 実行したいWorker自身が、自分に都合のよい`VERIFIED`を製造してはいけない
-- NazeYattaが評価するのはsupplied structure / linkage / policy conditionであり、v0.1-alphaでは現実世界のProducer本人性やAuthorityを独立にauthenticateしない
+- NazeYattaは渡された構造・関連・policy conditionを評価するが、現実世界で「誰がそのEvidenceを主張してよいか」まで独立に認証するものではない
 
 ```text
 Worker Self-Declaration != Evidence
 Producer Identity != Evidence Authority
 ```
 
-## Preflightのあと何が起きるの？
+## 次に読むなら
 
-```text
-Human / Planner / trusted Adapter
-        ↓
-     task YAML
-        ↓
-    NazeYatta
-        ↓
- preflight receipt
-        ↓
-authorized caller / control point
-        ↓
-別途authorizedされた場合だけexecute
-```
-
-non-`PASS`なら周囲のWorkflowに従ってStop / Reviewします。`PASS`が意味するのは、**supplied stateについて今回のPreflightを通過した**ということだけです。
-
-## ほかのExample
+まず安全なExampleを試したい場合：
 
 ```bash
 nazeyatta check examples/safe-read.yaml
@@ -133,6 +141,8 @@ nazeyatta check examples/provenance-qualified-safe-read.yaml
 nazeyatta check examples/provenance-claim-mismatch.yaml
 nazeyatta debrief-template NY-LIVE-001
 ```
+
+ここから下は、設計思想・Evidence・KY・現在の研究状態を詳しく説明します。
 
 ---
 
@@ -186,7 +196,7 @@ flowchart TB
     F --> G["🫵😿❓ NAZE YATTA?<br/>(なぜやった？ / 何が起きた？)"]
 ```
 
-現在の`v0.1-alpha`が実装しているのは、主に**Mandatory Ruleの決定論的Preflight lane**と**Structured Debrief Template**です。Runtime Observation AdapterやWorker自身によるSituational KY生成は、現時点では自動のend-to-end enforcementとしては未実装です。
+現在の`v0.1-alpha`が実装しているのは、主に**Mandatory Ruleの決論的Preflight lane**と**Structured Debrief Template**です。Runtime Observation AdapterやWorker自身によるSituational KY生成は、現時点では自動のend-to-end enforcementとしては未実装です。
 
 ## KY / 危険予知とは
 
@@ -337,7 +347,6 @@ KY PASS != Authority Granted
 **Helpful != Authorized.**
 
 ## Limitations
-
 NazeYattaは、AI Workerが必ず指示通り動くことを保証しません。PreflightだけではComplianceを強制できません。
 
 高ImpactなActionでは、Worker自身がbypassできないExternal Runtime Gateと組み合わせてください。

--- a/README.md
+++ b/README.md
@@ -2,23 +2,27 @@
 
 [English](README.md) | [日本語](README.ja.md)
 
-**NazeYatta** checks a small YAML task description against safety/policy rules **before an AI worker or software agent acts**.
+**NazeYatta is a check-before-you-act tool for AI workers and automation.**
 
-It returns a deterministic preflight result such as `PASS`, `REVIEW`, `EVIDENCE_REQUIRED`, or `BLOCK`, together with a receipt that explains what was checked.
+For example, if a task says "publish this photo" but publication permission has not been confirmed, NazeYatta can return `BLOCK` instead of guessing that permission exists. It returns a result such as `PASS`, `REVIEW`, or `BLOCK`, plus a record of what it checked.
+
+NazeYatta does not perform the task itself. It is a **preflight check before execution**.
+
+```text
+You / Planner
+     ↓
+"I want this task done"
+     ↓
+  NazeYatta
+     ↓
+PASS / REVIEW / BLOCK
+     ↓
+A separate authority decides whether execution may proceed
+```
 
 This is an alpha research tool. It is not a certification, adoption claim, or authority-granting system.
 
-## When should I use it?
-
-Use NazeYatta before actions where a worker should not rely on memory, self-confidence, or an unverified assumption alone, for example:
-
-- deleting or changing files;
-- `git push` or other external writes;
-- publishing content;
-- operations that require permission, capability, target verification, or evidence;
-- work where `UNKNOWN` must not silently become "probably safe".
-
-## Try it in about 30 seconds
+## Run it once
 
 Requires Python 3.11+.
 
@@ -32,7 +36,9 @@ python -m pip install -e .
 nazeyatta check examples/publish-photo.yaml
 ```
 
-You should see a result like:
+This example wants to publish something, but permission to publish has not been confirmed.
+
+So it returns `BLOCK`:
 
 ```text
 NAZEYATTA
@@ -48,17 +54,29 @@ NY-PUB-001  External publication requires verified provenance and permission
 EXECUTION AUTHORITY: NOT GRANTED BY NAZEYATTA
 ```
 
-In plain language: this example wants to publish something, but publication permission is still `UNKNOWN`, so the preflight blocks it instead of guessing that permission exists.
+In plain language:
 
-The joke is intentional. The evidence is not.
+> **"I cannot confirm that publishing is allowed, so I will not treat it as safe to continue."**
 
-## What does the result mean?
+The joke is intentional. **The evidence is not.**
+
+## When would I use it?
+
+Before an AI worker or automated tool does things such as:
+
+- deleting or changing files;
+- `git push` or other external writes;
+- publishing content;
+- actions that require permission, capability, target verification, or evidence;
+- work where `UNKNOWN` must not silently become "probably safe".
+
+## What do the results mean?
 
 - `PASS` — the supplied task, policy, and evidence passed this preflight.
-- `CAUTION` / `REVIEW` / `EVIDENCE_REQUIRED` — do not silently continue; follow the surrounding workflow and obtain the required review/evidence.
-- `BLOCK` — the policy says the action must stop under the supplied state.
+- `REVIEW` / `EVIDENCE_REQUIRED` / `CAUTION` — something still needs review or evidence; do not silently continue.
+- `BLOCK` — the action must stop under the supplied state.
 
-`0` means `PASS`. `CAUTION`, `REVIEW`, `EVIDENCE_REQUIRED`, and `BLOCK` return a non-zero exit status.
+Only `PASS` returns CLI exit status `0`. The other outcomes are non-zero.
 
 Most importantly:
 
@@ -66,11 +84,13 @@ Most importantly:
 KY PASS != Authority Granted
 ```
 
-A NazeYatta `PASS` does **not** grant execution authority. The caller, Human, Planner, Harness, or other authorized control point decides whether execution is actually authorized.
+**`PASS` is not permission to execute.** A Human, Planner, Harness, or other authorized control point separately decides whether execution is allowed.
 
-## Your first task
+## What do I give NazeYatta?
 
-A task file is a small YAML manifest describing the action and the evidence NazeYatta should evaluate. For a simple repository read, start with something like:
+You describe the task in a small YAML file.
+
+For a simple repository read, start with:
 
 ```yaml
 task_id: MY-FIRST-READ
@@ -92,39 +112,21 @@ Save it as `my-first-task.yaml`, then run:
 nazeyatta check my-first-task.yaml
 ```
 
-### Who is allowed to supply those fields?
+### Who is allowed to supply those facts?
 
-The v0.1-alpha ownership boundary is intentionally conservative:
+The v0.1-alpha boundary is intentionally conservative:
 
 - task/action/data facts should come from the upstream Human, Planner, task specification, or trusted adapter;
 - evidence should come from a Human, trusted adapter, or evidence source appropriate to the workflow;
 - the worker that wants to act must not manufacture its own `VERIFIED` facts;
-- NazeYatta evaluates the supplied structure, linkage, and policy conditions; it does **not** independently authenticate the real-world producer of those facts in v0.1-alpha.
+- NazeYatta evaluates supplied structure, linkage, and policy conditions; it does not independently prove who has real-world authority to assert those facts.
 
 ```text
 Worker Self-Declaration != Evidence
 Producer Identity != Evidence Authority
 ```
 
-## What happens after preflight?
-
-```text
-Human / Planner / trusted Adapter
-        ↓
-     task YAML
-        ↓
-    NazeYatta
-        ↓
- preflight receipt
-        ↓
-authorized caller / control point
-        ↓
-execute only if separately authorized
-```
-
-A non-`PASS` result means stop/review according to the surrounding workflow. A `PASS` means only that this preflight passed for the supplied state.
-
-## More examples
+## Try more examples
 
 ```bash
 nazeyatta check examples/safe-read.yaml
@@ -133,6 +135,8 @@ nazeyatta check examples/provenance-qualified-safe-read.yaml
 nazeyatta check examples/provenance-claim-mismatch.yaml
 nazeyatta debrief-template NY-LIVE-001
 ```
+
+The sections below explain the design philosophy, evidence model, KY inspiration, and current research state in more detail.
 
 ---
 
@@ -337,7 +341,6 @@ A `PASS` never manufactures authority:
 ```text
 KY PASS != Authority Granted
 ```
-
 And when a task contract says completion returns control to a Human, Planner, Reviewer, or other authority:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ A `PASS` never manufactures authority:
 ```text
 KY PASS != Authority Granted
 ```
+
 And when a task contract says completion returns control to a Human, Planner, Reviewer, or other authority:
 
 ```text


### PR DESCRIPTION
## Summary

Simplify the first screen of both README languages so a new user can form a mental model before encountering YAML / policy / evidence terminology.

- lead with: NazeYatta is a check-before-you-act tool;
- give one concrete publish-photo BLOCK example;
- explain PASS / REVIEW / BLOCK in plain language;
- introduce YAML only after the mental model and first run;
- preserve `PASS != execution authority`, evidence-ownership boundaries, alpha limitations, and all deeper research material.

Changed files only:
- `README.md`
- `README.ja.md`

No evaluator, policy, example, packaging, or runtime semantics changed.

Refs #4